### PR TITLE
Fix missing state history removal

### DIFF
--- a/collatz_ant.py
+++ b/collatz_ant.py
@@ -109,8 +109,6 @@ class CollatzAnt:
         self.grid[self.position] = self.start_value
         if self.version == "regular":
             self.orientation_mod = 4
-            color = self.grid[self.position] % 2
-            self._state_history[(self.position, self.orientation, color)] = 0
         elif self.version == "hexagonal":
             self.orientation_mod = 6
         else:


### PR DESCRIPTION
## Summary
- remove leftover state history code
- ensure CollatzAnt initializes without undefined attribute

## Testing
- `python -m py_compile collatz_ant.py visuals.py`
- `python collatz_ant.py 10 -s 5 --version regular`
- `python collatz_ant.py 10 -s 3 --version hexagonal`


------
https://chatgpt.com/codex/tasks/task_e_685102cd49d4832987e1c7e2c3db4dfa